### PR TITLE
Add absolute image positioning, textboxes and more

### DIFF
--- a/examples/make_docx_textbox_tableimage.js
+++ b/examples/make_docx_textbox_tableimage.js
@@ -1,0 +1,148 @@
+var async = require ( 'async' );
+var officegen = require('../');
+
+var fs = require('fs');
+var path = require('path');
+
+var docx = officegen ( {
+  type: 'docx',
+  orientation: 'landscape',
+  pageMargins: { top: 1000, left: 1000, bottom: 1000, right: 1000 },
+  pageSize: 'A4'
+} );
+
+// Remove this comment in case of debugging Officegen:
+// officegen.setVerboseMode ( true );
+
+docx.on ( 'error', function ( err ) {
+      console.log ( err );
+    });
+
+
+pObj = docx.createP ();
+pObj.addImage(path.resolve(__dirname, 'images_for_examples/image2.jpg'), {cx: 240, cy: 180, x: 800, y: 50});
+
+var tableData = [
+  [
+    {
+      val: 'Head1',
+      opts: {cellColWidth: 3000, b: true, align: 'center', sz: 22, gridSpan: 2, paddingTop: '0', paddingBottom: '0', lineHeight: 240, shd: {fill: 'e8e8e8'}}
+    },
+    {
+      val: [
+        {
+          type: "image",
+          path: path.resolve(__dirname, 'images_for_examples/image1.png'),
+          text: 'Example image column',
+          opts: {
+            anchoredImage: true,
+            cx: 200,
+            cy: 100,
+            sz: 22,
+            offsetV: 200000,
+            offsetH: 400000,
+            align: 'center',
+            fontFamily: 'SimSun',
+            lineHeight: 240,
+            paddingTop: '0',
+            paddingBottom: '0',
+            b: true
+          }
+        },
+      ],
+      opts: {cellColWidth: 4500, shd: {fill: 'e8e8e8'}}
+    }
+  ],
+  [
+    {
+      val: 'Cell 01',
+      opts: {cellColWidth: 1500}
+    },
+    {
+      val: 'Cell 02',
+      opts: {cellColWidth: 1500, vAlign: 'bottom', paddingTop: '0', paddingBottom: '0', lineHeight: 240}
+    }
+  ],
+  [
+    {
+      val: 'Cell 11',
+      opts: {cellColWidth: 1500, vAlign: 'top', align: 'right', paddingTop: '0', paddingBottom: '0', lineHeight: 240}
+    },
+    {
+      val: 'Cell 12',
+      opts: {
+        borders: {
+          left: true,
+          right: true
+        },
+      }
+    }
+  ],
+  [
+    {
+      val: 'Cell 21'
+    },
+    {
+      val: 'Cell 22',
+      opts: {
+        borders: {
+          top: true
+        },
+      }
+    }
+  ],
+  [
+    {
+      val: 'Cell 31',
+      opts: {
+        borders: {
+          bottom: true
+        },
+      }
+    },
+    {
+      val: 'Cell 32'
+    }
+  ]
+];
+docx.createTable(tableData);
+
+pObj.startTextbox(450, 200, 300, 200, {
+  lineHeight: 480
+});
+pObj.addText('This is a textbox', {bold: true, font_face: 'Arial', font_size: 10});
+pObj.addLineBreak();
+pObj.addText('You can add texts as usual', {font_face: 'Arial', font_size: 8});
+pObj.addLineBreak();
+pObj.addText(
+`Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.`
+);
+pObj.endTextbox();
+
+var out = fs.createWriteStream ( 'tmp/out.docx' );
+
+out.on ( 'error', function ( err ) {
+  console.log ( err );
+});
+
+async.parallel ([
+  function ( done ) {
+    out.on ( 'close', function () {
+      console.log ( 'Finish to create a DOCX file.' );
+      done ( null );
+    });
+    docx.generate ( out );
+  }
+
+], function ( err ) {
+  if ( err ) {
+    console.log ( 'error: ' + err );
+  } // Endif.
+});

--- a/lib/docx-p.js
+++ b/lib/docx-p.js
@@ -129,6 +129,34 @@ MakeDocxP.prototype.endBookmark = function () {
 };
 
 /**
+ * Insert a textbox here.
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
+MakeDocxP.prototype.startTextbox = function ( x, y, width, height ) {
+	var newP = this;
+	newP.data[newP.data.length] = {
+		'textbox_start': true,
+		'opts': {
+			'marginLeft': x,
+			'marginTop': y,
+			'width': width,
+			'height': height
+		}
+	};
+};
+
+/**
+ * Close the previous placed textbox.
+ */
+MakeDocxP.prototype.endTextbox = function () {
+	var newP = this;
+	newP.data[newP.data.length] = { 'textbox_end': true };
+};
+
+/**
  * Insert an image into the current paragraph.
  *
  * @param {object} image_path The image file to add.

--- a/lib/docx-p.js
+++ b/lib/docx-p.js
@@ -135,7 +135,7 @@ MakeDocxP.prototype.endBookmark = function () {
  * @param {number} width
  * @param {number} height
  */
-MakeDocxP.prototype.startTextbox = function ( x, y, width, height ) {
+MakeDocxP.prototype.startTextbox = function ( x, y, width, height, opts={} ) {
 	var newP = this;
 	newP.data[newP.data.length] = {
 		'textbox_start': true,
@@ -143,7 +143,9 @@ MakeDocxP.prototype.startTextbox = function ( x, y, width, height ) {
 			'marginLeft': x,
 			'marginTop': y,
 			'width': width,
-			'height': height
+			'height': height,
+			'lineHeight': opts.lineHeight || "360",
+			'lineRule': opts.lineRule || "auto"
 		}
 	};
 };

--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -313,7 +313,7 @@ module.exports = {
             "@distL": "0",
             "@distR": "0",
 
-            "wp:extent": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cx * Math.floor(12573.739)) },
+            "wp:extent": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cy * Math.floor(12573.739)) },
 
             "wp:effectExtent": { "@l": "0", "@t": "0", "@r": "0", "@b": "0" },
 
@@ -345,7 +345,7 @@ module.exports = {
                   "pic:spPr": {
                     "a:xfrm": {
                       "a:off": { "@x": "0", "@y": "0" },
-                      "a:ext": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cx * Math.floor(12573.739)) }
+                      "a:ext": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cy * Math.floor(12573.739)) }
                     },
                     "a:prstGeom": {
                       "@prst": "rect",
@@ -383,7 +383,7 @@ module.exports = {
                 "wp:posOffset": image.options.offsetV || "240503"
               },
 
-              "wp:extent": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cx * Math.floor(12573.739)) },
+              "wp:extent": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cy * Math.floor(12573.739)) },
 
               "wp:effectExtent": { "@l": "0", "@t": "0", "@r": "0", "@b": "0" },
 
@@ -417,7 +417,7 @@ module.exports = {
                     "pic:spPr": {
                       "a:xfrm": {
                         "a:off": { "@x": "0", "@y": "0" },
-                        "a:ext": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cx * Math.floor(12573.739)) }
+                        "a:ext": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cy * Math.floor(12573.739)) }
                       },
                       "a:prstGeom": {
                         "@prst": "rect",

--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -358,6 +358,79 @@ module.exports = {
           }
         }
 
+        if (cell.opts.anchoredImage) {
+          img = {
+            "wp:anchor": {
+              "@allowOverlap": "1",
+              "@behindDoc": "0",
+              "@distB": "0",
+              "@distL": "0",
+              "@distR": "0",
+              "@distT": "10000",
+              "@layoutInCell": "1",
+              "@locked": "0",
+              "@relativeHeight": "251656192",
+              "@simplePos": "0",
+
+              "wp:simplePos": { "@x": "0", "@y": "0" },
+
+              "wp:positionH": {
+                "@relativeFrom": "page",
+                "wp:posOffset": image.options.offsetH || "191106"
+              },
+              "wp:positionV": {
+                "@relativeFrom": "page",
+                "wp:posOffset": image.options.offsetV || "240503"
+              },
+
+              "wp:extent": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cx * Math.floor(12573.739)) },
+
+              "wp:effectExtent": { "@l": "0", "@t": "0", "@r": "0", "@b": "0" },
+
+              "wp:wrapNone": {},
+
+              "wp:docPr": { "@id": "1", "@name": "Picture 0", "@descr": "Picture 0" },
+
+              "wp:cNvGraphicFramePr": {
+                "a:graphicFrameLocks": {
+                  "@xmlns:a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+                  "@noChangeAspect": "1"
+                }
+              },
+
+              "a:graphic": {
+                "@xmlns:a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+                "a:graphicData": {
+                  "@uri": "http://schemas.openxmlformats.org/drawingml/2006/picture",
+                  "pic:pic": {
+                    "@xmlns:pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",
+                    "pic:nvPicPr": {
+                      "pic:cNvPr": { "@id": image.image_id, "@name": "Picture 0" },
+                      "pic:cNvPicPr": {}
+                    },
+                    "pic:blipFill": {
+                      "a:blip": { "@r:embed": "rId" + image.rel_id, "@cstate": "print" },
+                      "a:stretch": {
+                        "a:fillRect": {}
+                      }
+                    },
+                    "pic:spPr": {
+                      "a:xfrm": {
+                        "a:off": { "@x": "0", "@y": "0" },
+                        "a:ext": { "@cx": (image.options.cx * Math.floor(12573.739)), "@cy": (image.options.cx * Math.floor(12573.739)) }
+                      },
+                      "a:prstGeom": {
+                        "@prst": "rect",
+                        "a:avLst": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
         let cellText = "";
         if (cell.text) {
           //if we have a text inline with the image add a space between the image & the text
@@ -379,8 +452,8 @@ module.exports = {
                     "@w:val": cell.opts.align || "center"
                   },
                   "w:spacing": { // add some padding above and below so the image doesn't overlap the borders of the table
-                    "@w:before": "100",
-                    "@w:after": "60",
+                    "@w:before": cell.opts.paddingTop || "100",
+                    "@w:after": cell.opts.paddingBottom || "60",
                   }
                 },
                 "w:tcPr": {

--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -362,7 +362,7 @@ module.exports = {
           img = {
             "wp:anchor": {
               "@allowOverlap": "1",
-              "@behindDoc": "0",
+              "@behindDoc": "1",
               "@distB": "0",
               "@distL": "0",
               "@distR": "0",
@@ -442,55 +442,7 @@ module.exports = {
           }
         }
 
-
-        if (cell.opts.textAfterImage) {
-          return ret = [
-            {
-              "w:p": {
-                "w:pPr": {
-                  "w:jc": {
-                    "@w:val": cell.opts.align || "center"
-                  },
-                  "w:spacing": { // add some padding above and below so the image doesn't overlap the borders of the table
-                    "@w:before": cell.opts.paddingTop || "100",
-                    "@w:after": cell.opts.paddingBottom || "60",
-                  }
-                },
-                "w:tcPr": {
-                  "w:vAlign": {
-                    "@w:val": "center"
-                  }
-                },
-                "w:r": {
-                  "@w:rsidRPr": "00722E63",
-                  "w:rPr": {
-                    "w:rFonts": {
-                      "@w:ascii": cell.opts.fontFamily || "Avenir Book",
-                      "@w:hAnsi": cell.opts.fontFamily || "Avenir Book"
-                    },
-                    "w:color": {
-                      "@w:val": cell.opts.color || "000"
-                    },
-                    "w:b": {},
-                    "w:sz": {
-                      "@w:val": cell.opts.sz || "16"
-                    },
-                    "w:szCs": {
-                      "@w:val": cell.opts.sz || "16"
-                    }
-                  },
-                  "w:t": {
-                    "@xml:space": "preserve", // we must have a space between the image and the text
-                    "#text": cellText, // check xmlbuilder doc to see how to add text nodes
-                  },
-                  "w:drawing": img
-                }
-              }
-            }
-          ]
-        }
-
-        return ret = [
+        var ret = [
           {
             "w:p": {
               "w:pPr": {
@@ -498,8 +450,10 @@ module.exports = {
                   "@w:val": cell.opts.align || "center"
                 },
                 "w:spacing": { // add some padding above and below so the image doesn't overlap the borders of the table
-                  "@w:before": "100",
-                  "@w:after": "60",
+                  "@w:before": cell.opts.paddingTop || "100",
+                  "@w:after": cell.opts.paddingBottom || "60",
+                  "@w:line": cell.opts.lineHeight || "276",
+                  "@w:lineRule": cell.opts.lineRule || "auto",
                 }
               },
               "w:tcPr": {
@@ -517,6 +471,7 @@ module.exports = {
                   "w:color": {
                     "@w:val": cell.opts.color || "000"
                   },
+                  "w:b": {},
                   "w:sz": {
                     "@w:val": cell.opts.sz || "16"
                   },
@@ -524,15 +479,30 @@ module.exports = {
                     "@w:val": cell.opts.sz || "16"
                   }
                 },
-                "w:drawing": img,
-                "w:t": {
-                  "@xml:space": "preserve", // we must have a space between the image and the text
-                  "#text": cellText, // check xmlbuilder doc to see how to add text nodes
-                }
               }
             }
           }
-        ]
+        ];
+
+        if (!cell.opts.b) {
+          delete ret[0]["w:p"]["w:r"]["w:rPr"]["w:b"];
+        }
+
+        if (cell.opts.textAfterImage) {
+          ret[0]["w:p"]["w:r"]["w:t"] = {
+            "@xml:space": "preserve", // we must have a space between the image and the text
+            "#text": cellText, // check xmlbuilder doc to see how to add text nodes
+          };
+          ret[0]["w:p"]["w:r"]["w:drawing"] = img;
+        } else {
+          ret[0]["w:p"]["w:r"]["w:drawing"] = img;
+          ret[0]["w:p"]["w:r"]["w:t"] = {
+            "@xml:space": "preserve", // we must have a space between the image and the text
+            "#text": cellText, // check xmlbuilder doc to see how to add text nodes
+          };
+        }
+
+        return ret;
       }
       if (!cell.type && cell.inline) {
         var opts = cell.opts || {};

--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -187,6 +187,35 @@ module.exports = {
         "@w:val": opts.vAlign
       };
     }
+    var cellBorders = {};
+    function parseBorder(border) {
+      if (border) {
+        return {
+          "@w:color": border.color || "auto",
+          "@w:space": border.space || "0",
+          "@w:sz": border.sz || "4",
+          "@w:val": border.val || "single"
+        };
+      }
+      return null;
+    }
+    if (opts.borders) {
+      if (opts.borders.left) {
+        cellBorders["w:left"] = parseBorder(opts.borders.left);
+      }
+      if (opts.borders.right) {
+        cellBorders["w:right"] = parseBorder(opts.borders.right);
+      }
+      if (opts.borders.top) {
+        cellBorders["w:top"] = parseBorder(opts.borders.top);
+      }
+      if (opts.borders.bottom) {
+        cellBorders["w:bottom"] = parseBorder(opts.borders.bottom);
+      }
+    }
+    if (Object.keys(cellBorders).length > 0) {
+      cellObj["w:tc"]["w:tcPr"]["w:tcBorders"] = cellBorders;
+    }
     return cellObj;
   },
   _getComplexCell: function (cellVal, tblOpts) {

--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -123,6 +123,8 @@ module.exports = {
           "w:spacing": {
             "@w:before": opts.paddingTop || "120",
             "@w:after": opts.paddingBottom || "60",
+            "@w:line": opts.lineHeight || "276",
+            "@w:lineRule": opts.lineRule || "auto",
           },
         },
         "w:r": {

--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -175,6 +175,16 @@ module.exports = {
 
       }
     }
+    if (opts.gridSpan) {
+      cellObj["w:tc"]["w:tcPr"]["w:gridSpan"] = {
+        "@w:val": opts.gridSpan
+      };
+    }
+    if (opts.vAlign) {
+      cellObj["w:tc"]["w:tcPr"]["w:vAlign"] = {
+        "@w:val": opts.vAlign
+      };
+    }
     return cellObj;
   },
   _getComplexCell: function (cellVal, tblOpts) {

--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -367,6 +367,11 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
 						outString += '<v:textbox>';
 						outString += '<w:txbxContent>';
 						outString += '<w:p w:rsidR="0026655B" w:rsidRDefault="0026655B">';
+						if (objs_list[i].data[j].opts.lineHeight || objs_list[i].data[j].opts.lineRule) {
+							outString += '<w:pPr>';
+							outString += '<w:spacing w:line="' + objs_list[i].data[j].opts.lineHeight + '" w:lineRule="' + objs_list[i].data[j].opts.lineRule + '"/>';
+							outString += '</w:pPr>';
+						}
 
 					} else if (objs_list[i].data[j].textbox_end) {
 						outString += '</w:p>';

--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -367,11 +367,27 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
 
 						//914400L / 96DPI
 						var pixelToEmu = 9525;
+						var absolutePosition = objs_list[i].data[j].options.x && objs_list[i].data[j].options.y;
 
 						outString += '<w:drawing>';
-						outString += '<wp:inline distT="0" distB="0" distL="0" distR="0">';
+						if (absolutePosition) {
+							outString += '<wp:anchor distT="10000" distB="0" distL="0" distR="0" simplePos="1" relativeHeight="251658239" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">';
+							outString += '<wp:simplePos  x="' + objs_list[i].data[j].options.x * pixelToEmu + '" y="' + objs_list[i].data[j].options.y * pixelToEmu + '" />';
+							outString += '<wp:positionH relativeFrom="page">';
+							outString += '<wp:posOffset>' + (objs_list[i].data[j].options.x * pixelToEmu) + '</wp:posOffset>';
+							outString += '</wp:positionH>';
+							outString += '<wp:positionV relativeFrom="page">';
+							outString += '<wp:posOffset>' + (objs_list[i].data[j].options.y * pixelToEmu) + '</wp:posOffset>';
+							outString += '</wp:positionV>';
+						} else {
+							outString += '<wp:inline distT="0" distB="0" distL="0" distR="0">';
+						}
 						outString += '<wp:extent cx="' + (objs_list[i].data[j].options.cx * pixelToEmu) + '" cy="' + (objs_list[i].data[j].options.cy * pixelToEmu) + '"/>';
 						outString += '<wp:effectExtent l="19050" t="0" r="9525" b="0"/>';
+
+						if (absolutePosition) {
+							outString += '<wp:wrapNone />';
+						}
 
 						outString += '<wp:docPr id="' + (objs_list[i].data[j].image_id + 1) + '" name="Picture ' + objs_list[i].data[j].image_id + '" descr="Picture ' + objs_list[i].data[j].image_id + '">';
 						if (objs_list[i].data[j].link_rel_id) {
@@ -407,7 +423,11 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
 						outString += '</pic:pic>';
 						outString += '</a:graphicData>';
 						outString += '</a:graphic>';
-						outString += '</wp:inline>';
+						if (absolutePosition) {
+							outString += '</wp:anchor>';
+						} else {
+							outString += '</wp:inline>';
+						}
 						outString += '</w:drawing>';
 
 						outString += '</w:r>';
@@ -483,7 +503,6 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
 		} // Endif.
 
 		outString += data.docEndExtra + '</w:' + data.docType + '>';
-
 		return outString;
 	}
 

--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -367,7 +367,7 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
 
 						//914400L / 96DPI
 						var pixelToEmu = 9525;
-						var absolutePosition = objs_list[i].data[j].options.x && objs_list[i].data[j].options.y;
+						var absolutePosition = objs_list[i].data[j].options.x >= 0 && objs_list[i].data[j].options.y >= 0;
 
 						outString += '<w:drawing>';
 						if (absolutePosition) {

--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -356,6 +356,25 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
 						outString += '<w:bookmarkEnd w:id="' + bookmarkId + '"/>';
 						bookmarkId++;
 
+					} else if (objs_list[i].data[j].textbox_start) {
+						var style = 'position:absolute;margin-left:' + objs_list[i].data[j].opts.marginLeft + 'pt;margin-top:' + objs_list[i].data[j].opts.marginTop + 'pt;width:' + objs_list[i].data[j].opts.width + 'pt;height:' + objs_list[i].data[j].opts.height + 'pt;z-index:251659263'
+						outString += '<w:pict>';
+						outString += '<v:shapetype coordsize="21600,21600" id="_x0000_t202" o:spt="202" path="m,l,21600r21600,l21600,xe">';
+						outString += '<v:stroke joinstyle="miter"/>';
+						outString += '<v:path gradientshapeok="t" o:connecttype="rect"/>';
+						outString += '</v:shapetype>';
+						outString += '<v:shape id="_x0000_s1026" stroked="f" style="' + style + '" type="#_x0000_t202">';
+						outString += '<v:textbox>';
+						outString += '<w:txbxContent>';
+						outString += '<w:p w:rsidR="0026655B" w:rsidRDefault="0026655B">';
+
+					} else if (objs_list[i].data[j].textbox_end) {
+						outString += '</w:p>';
+						outString += '</w:txbxContent>';
+						outString += '</v:textbox>';
+						outString += '</v:shape>';
+						outString += '</w:pict>';
+
 					} else if (objs_list[i].data[j].image) {
 						outString += '<w:r' + rExtra + '>';
 


### PR DESCRIPTION
Hi,
in the past few days I added a bunch of new functions.
Please checkout the example [/examples/make_docx_textbox_tableimage.js](https://github.com/dominik-th/officegen/blob/cc599a456ccd0a1d83e2fc5d11dfac04358dde0c/examples/make_docx_textbox_tableimage.js) to see any these features in action.

In short, I added:

- Absolute image positioning with addImage()
- Textbox creation with pObj.startTextbox() and pObj.endTextbox()
- Gridspan and vAlign back in from [Ziv-Barber/officegen](https://github.com/Ziv-Barber/officegen)
- lineHeight option for table cell spacing
- Adjustable table cell borders
- A way to add images anchored to a table cell